### PR TITLE
Set prometheus retention rate to 3900MB

### DIFF
--- a/deploy/ngsadev/monitoring/02-prometheus.yaml
+++ b/deploy/ngsadev/monitoring/02-prometheus.yaml
@@ -215,6 +215,7 @@ spec:
           args:
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus/"
+            - "--storage.tsdb.retention.size=3900MB"            
           ports:
             - containerPort: 9090
           volumeMounts:

--- a/deploy/ngsaprec/monitoring/02-prometheus.yaml
+++ b/deploy/ngsaprec/monitoring/02-prometheus.yaml
@@ -215,6 +215,7 @@ spec:
           args:
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus/"
+            - "--storage.tsdb.retention.size=3900MB"            
           ports:
             - containerPort: 9090
           volumeMounts:

--- a/templates/prometheus.yaml
+++ b/templates/prometheus.yaml
@@ -215,6 +215,7 @@ spec:
           args:
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus/"
+            - "--storage.tsdb.retention.size=3900MB"
           ports:
             - containerPort: 9090
           volumeMounts:


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
To fix bug in which prometheus restarts due to running out of space. Setting a boundary for retention to 3900MB since the PVC is currently set to 4GB.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Validation

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/422

