### PR TITLE
Feature/istio pod logs

### DIFF
--- a/deploy/ngsadev/fluentbit/config-log.yaml
+++ b/deploy/ngsadev/fluentbit/config-log.yaml
@@ -9,3 +9,4 @@ data:
   region: westus
   lodeLog: loderunner
   ngsaLog: ngsa
+  istioLog: ingress

--- a/deploy/ngsadev/fluentbit/config.yaml
+++ b/deploy/ngsadev/fluentbit/config.yaml
@@ -30,10 +30,17 @@ data:
         storage.total_limit_size  15M
     [OUTPUT]
         Name            azure
-        Match           kube.var.log.containers.ngsa*.*
+        Match           kube.var.log.containers.ngsa*_ngsa*
         Customer_ID     ${WORKSPACE_ID}
         Shared_Key      ${SHARED_KEY}
         Log_Type        ${NGSA_LOG}
+        storage.total_limit_size  15M
+    [OUTPUT]
+        Name            azure
+        Match           kube.var.log.containers.ngsa*_istio-proxy*
+        Customer_ID     ${WORKSPACE_ID}
+        Shared_Key      ${SHARED_KEY}
+        Log_Type        ${ISTIO_LOG}
         storage.total_limit_size  15M
   input-kubernetes.conf: |
     [INPUT]

--- a/deploy/ngsadev/fluentbit/daemonset.yaml
+++ b/deploy/ngsadev/fluentbit/daemonset.yaml
@@ -61,6 +61,11 @@ spec:
                 configMapKeyRef:
                   name: fluentbit-log-config
                   key: ngsaLog
+            - name: ISTIO_LOG
+              valueFrom:
+                configMapKeyRef:
+                  name: fluentbit-log-config
+                  key: istioLog
             - name: LODE_LOG
               valueFrom:
                 configMapKeyRef:

--- a/deploy/ngsadev/ngsa/dev/ngsa-envoy-filter.yaml
+++ b/deploy/ngsadev/ngsa/dev/ngsa-envoy-filter.yaml
@@ -1,0 +1,46 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: ngsa-sidecar-log
+  namespace: ngsa
+spec:
+  # Applying to all sidecars in ngsa namespace
+  # If want to apply to a specific pod/deployment
+  # Uncomment the lines below and use label properly
+  # workloadSelector:
+  #   labels:
+  #     app: ngsa-memory
+  configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.filters.network.http_connection_manager"
+    patch:
+      operation: MERGE
+      value:
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
+          access_log:
+          - name: envoy.access_loggers.file
+            typed_config:
+              "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog"
+              path: /dev/stdout
+              log_format: 
+                json_format:
+                  Date: "%START_TIME%"
+                  LogName: "Istio.envoy-proxy"
+                  StatusCode: "%RESPONSE_CODE%"
+                  TTFB: ""
+                  Duration: "%DURATION%"
+                  Verb: "%REQ(:METHOD)%"
+                  Path: "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"
+                  Host: "%REQ(:AUTHORITY)%"
+                  ClientIP: "%UPSTREAM_LOCAL_ADDRESS%"
+                  XFF: "%REQ(X-FORWARDED-FOR)%"
+                  UserAgent: "%REQ(USER-AGENT)%"
+                  CVector: ""
+                  CVectorBase: ""
+                  Category: "istio"
+                  Subcategory: "envoy-sidecar-proxy"

--- a/deploy/ngsadev/ngsa/namespace.yaml
+++ b/deploy/ngsadev/ngsa/namespace.yaml
@@ -3,4 +3,5 @@ kind: Namespace
 metadata:
   labels:
     name: ngsa
+    istio-injection: enabled
   name: ngsa


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [X] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR
Sends Istio Envoy sidecar Logs to log analytics

Changes:
- Enable sidecar injection
- FluentBit configuration (to create a new table named `ingress` for istio envoy sidecar)
- Adds EnvoyFilter to enable and modify sidecar logging format

## Does this introduce a breaking change

- [X] YES
- [ ] NO

This enabled istio sidecar injection in ngsa namespace and adds EnvoyFilter targeting Ngsa namespace.

# Verification
Check logs in Log Analytics in: 
https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/648dcb5a-de1e-48b2-af6b-fe6ef28d355c/resourceGroups/rg-ngsa-pre-central-dev/providers/Microsoft.OperationalInsights/workspaces/la-aks-6jqf6qyt7jarg/logs
![image](https://user-images.githubusercontent.com/11367790/144145066-9aef4117-b767-4e38-96a9-b402ecfb3e42.png)


## Issues Closed or Referenced

- Closes #https://github.com/retaildevcrews/wcnp/issues/426