### PR TITLE
Checkov updates for Grafana

### DIFF
--- a/deploy/dev-ngsa-asb-eastus/monitoring/grafana/05-grafana.yaml
+++ b/deploy/dev-ngsa-asb-eastus/monitoring/grafana/05-grafana.yaml
@@ -13,6 +13,8 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    checkov.io/skip1: CKV_K8S_35=Grafana container requires env var for secret value
   labels:
     app: grafana
   name: grafana
@@ -28,8 +30,11 @@ spec:
         app: grafana
         aadpodidbinding: grafana-id
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 472
+        seccompProfile:
+          type: RuntimeDefault
         supplementalGroups:
           - 0
       containers:
@@ -75,6 +80,14 @@ spec:
             requests:
               memory: "512Mi"
               cpu: "500m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-pv

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
@@ -13,8 +13,6 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    checkov.io/skip1: CKV_K8S_35=Grafana container requires env var for secret value
   labels:
     app: grafana
   name: grafana

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
@@ -28,8 +28,11 @@ spec:
         app: grafana
         aadpodidbinding: grafana-id
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 472
+        seccompProfile:
+          type: RuntimeDefault
         supplementalGroups:
           - 0
       containers:
@@ -75,6 +78,14 @@ spec:
             requests: 
               memory: "512Mi"
               cpu: "500m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-pv

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
@@ -78,6 +78,8 @@ spec:
             requests: 
               memory: "512Mi"
               cpu: "500m"
+          securityContext:
+            allowPrivilegeEscalation: false
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-pv

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
@@ -13,6 +13,8 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    checkov.io/skip1: CKV_K8S_35=Grafana container requires env var for secret value
   labels:
     app: grafana
   name: grafana

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
@@ -28,6 +28,7 @@ spec:
         app: grafana
         aadpodidbinding: grafana-id
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 472
         supplementalGroups:

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
@@ -80,6 +80,9 @@ spec:
               cpu: "500m"
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-pv

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
@@ -31,6 +31,8 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         fsGroup: 472
+        seccompProfile:
+          type: RuntimeDefault
         supplementalGroups:
           - 0
       containers:

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
@@ -84,6 +84,8 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-pv

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
@@ -83,6 +83,7 @@ spec:
             capabilities:
               drop:
                 - ALL
+            readOnlyRootFilesystem: true
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-pv

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
@@ -13,6 +13,8 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    checkov.io/skip1: CKV_K8S_35=Grafana container requires env var for secret value
   labels:
     app: grafana
   name: grafana
@@ -28,11 +30,8 @@ spec:
         app: grafana
         aadpodidbinding: grafana-id
     spec:
-      automountServiceAccountToken: false
       securityContext:
         fsGroup: 472
-        seccompProfile:
-          type: RuntimeDefault
         supplementalGroups:
           - 0
       containers:
@@ -78,14 +77,6 @@ spec:
             requests: 
               memory: "512Mi"
               cpu: "500m"
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 10001
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-pv

--- a/deploy/pre-ngsa-asb-centralus/monitoring/grafana/05-grafana.yaml
+++ b/deploy/pre-ngsa-asb-centralus/monitoring/grafana/05-grafana.yaml
@@ -13,6 +13,8 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    checkov.io/skip1: CKV_K8S_35=Grafana container requires env var for secret value
   labels:
     app: grafana
   name: grafana
@@ -28,8 +30,11 @@ spec:
         app: grafana
         aadpodidbinding: grafana-id
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 472
+        seccompProfile:
+          type: RuntimeDefault
         supplementalGroups:
           - 0
       containers:
@@ -75,6 +80,14 @@ spec:
             requests: 
               memory: "512Mi"
               cpu: "500m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-pv

--- a/deploy/pre-ngsa-asb-eastus/monitoring/grafana/05-grafana.yaml
+++ b/deploy/pre-ngsa-asb-eastus/monitoring/grafana/05-grafana.yaml
@@ -13,6 +13,8 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    checkov.io/skip1: CKV_K8S_35=Grafana container requires env var for secret value
   labels:
     app: grafana
   name: grafana
@@ -28,8 +30,11 @@ spec:
         app: grafana
         aadpodidbinding: grafana-id
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 472
+        seccompProfile:
+          type: RuntimeDefault
         supplementalGroups:
           - 0
       containers:
@@ -75,6 +80,14 @@ spec:
             requests:
               memory: "512Mi"
               cpu: "500m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-pv

--- a/deploy/pre-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
+++ b/deploy/pre-ngsa-asb-westus2/monitoring/grafana/05-grafana.yaml
@@ -13,6 +13,8 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    checkov.io/skip1: CKV_K8S_35=Grafana container requires env var for secret value
   labels:
     app: grafana
   name: grafana
@@ -28,8 +30,11 @@ spec:
         app: grafana
         aadpodidbinding: grafana-id
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 472
+        seccompProfile:
+          type: RuntimeDefault
         supplementalGroups:
           - 0
       containers:
@@ -75,6 +80,14 @@ spec:
             requests: 
               memory: "512Mi"
               cpu: "500m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-pv

--- a/templates/monitoring/03-grafana-aad.yaml
+++ b/templates/monitoring/03-grafana-aad.yaml
@@ -35,6 +35,8 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    checkov.io/skip1: CKV_K8S_35=Grafana container requires env var for secret value
   labels:
     app: grafana
   name: grafana
@@ -50,8 +52,11 @@ spec:
         app: grafana
         aadpodidbinding: ${ASB_GRAFANA_MI_NAME}
     spec:
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 472
+        seccompProfile:
+          type: RuntimeDefault
         supplementalGroups:
           - 0
       containers:
@@ -97,6 +102,14 @@ spec:
             requests: 
               memory: "512Mi"
               cpu: "500m"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
           volumeMounts:
             - mountPath: /var/lib/grafana
               name: grafana-pv


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
- Update Grafana yaml in the deploy directory for clusters as well as the template (created a note on the board to track the work for syncing the template yamls with what is actually running on the clusters)
- I verified this eliminated all of the Checkov warnings by running checkov locally in CS
- I temporarily updated flux to point to my branch to test the deployment of Grafana in the dev westus2 cluster.  The pod restarted with no issue and I was able to access Grafana via the browser and load all 3 dashboards.  
- I currently have it set to skip CKV_K8S_35 (Prefer using secrets as files over secrets as environment variables | https://docs.bridgecrew.io/docs/bc_k8s_33), as the envvar that violates it is [GF_AUTH_AZUREAD_CLIENT_SECRET](https://grafana.com/docs/grafana/latest/auth/azuread/#enable-azure-ad-oauth-in-grafana). It is possible to add the secret directly into the Grafana config file but that would involve adding the whole file as a secret into key vault.  If this ends up being the preferred way to go, we can create an issue to track the change and remove the annotation. 

## Does this introduce a breaking change

- [ ] YES
- [ ] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Validation

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes #issue_number (this will automatically close the issue when the PR closes)
- References #issue_number (this references the issue but does not close with PR)
