### PR TITLE
Removed Dev/Pre from Grafana dashboard title

### DIFF
--- a/deploy/dev-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-az-blocked-traffic.yaml
+++ b/deploy/dev-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-az-blocked-traffic.yaml
@@ -886,7 +886,7 @@ data:
           },
           "timepicker": {},
           "timezone": "",
-          "title": "NGSA Dev - Blocked Traffic",
+          "title": "NGSA - Blocked Traffic",
           "uid": "PpsPzW8nk",
           "version": 11
         }

--- a/deploy/dev-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-az-monitor-perf.yaml
+++ b/deploy/dev-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-az-monitor-perf.yaml
@@ -2677,7 +2677,7 @@ data:
           },
           "timepicker": {},
           "timezone": "browser",
-          "title": "NGSA Dev - Azure Monitor - Performance",
+          "title": "NGSA - Azure Monitor - Performance",
           "uid": "2IRD5FSnp",
           "version": 2,
           "weekStart": ""

--- a/deploy/dev-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-az-monitor-rel.yaml
+++ b/deploy/dev-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-az-monitor-rel.yaml
@@ -2388,7 +2388,7 @@ data:
           },
           "timepicker": {},
           "timezone": "browser",
-          "title": "NGSA Dev - Azure Monitor - Reliability",
+          "title": "NGSA - Azure Monitor - Reliability",
           "uid": "2IRD5FSnr",
           "version": 1,
           "weekStart": ""

--- a/deploy/dev-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-fluentbit.yaml
+++ b/deploy/dev-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-fluentbit.yaml
@@ -747,7 +747,7 @@ data:
             ]
           },
           "timezone": "",
-          "title": "NGSA Dev - Fluent Bit",
+          "title": "NGSA - Fluent Bit",
           "uid": "fluentbit",
           "version": 2,
           "weekStart": ""

--- a/deploy/dev-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-prometheus.yaml
+++ b/deploy/dev-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-prometheus.yaml
@@ -794,7 +794,7 @@ data:
           ]
         },
         "timezone": "",
-        "title": "NGSA Dev - Prometheus",
+        "title": "NGSA - Prometheus",
         "uid": "J20-83NHf",
         "version": 1
         }

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-az-blocked-traffic.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-az-blocked-traffic.yaml
@@ -886,7 +886,7 @@ data:
           },
           "timepicker": {},
           "timezone": "",
-          "title": "NGSA Dev - Blocked Traffic",
+          "title": "NGSA - Blocked Traffic",
           "uid": "PpsPzW8nk",
           "version": 11
         }

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-az-monitor-perf.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-az-monitor-perf.yaml
@@ -2677,7 +2677,7 @@ data:
           },
           "timepicker": {},
           "timezone": "browser",
-          "title": "NGSA Dev - Azure Monitor - Performance",
+          "title": "NGSA - Azure Monitor - Performance",
           "uid": "2IRD5FSnp",
           "version": 2,
           "weekStart": ""

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-az-monitor-rel.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-az-monitor-rel.yaml
@@ -2388,7 +2388,7 @@ data:
           },
           "timepicker": {},
           "timezone": "browser",
-          "title": "NGSA Dev - Azure Monitor - Reliability",
+          "title": "NGSA - Azure Monitor - Reliability",
           "uid": "2IRD5FSnr",
           "version": 1,
           "weekStart": ""

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-fluentbit.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-fluentbit.yaml
@@ -747,7 +747,7 @@ data:
             ]
           },
           "timezone": "",
-          "title": "NGSA Dev - Fluent Bit",
+          "title": "NGSA - Fluent Bit",
           "uid": "fluentbit",
           "version": 2,
           "weekStart": ""

--- a/deploy/dev-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-prometheus.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-prometheus.yaml
@@ -794,7 +794,7 @@ data:
           ]
         },
         "timezone": "",
-        "title": "NGSA Dev - Prometheus",
+        "title": "NGSA - Prometheus",
         "uid": "J20-83NHf",
         "version": 3 
         }

--- a/deploy/pre-ngsa-asb-centralus/monitoring/grafana/dashboards/ngsa-az-monitor-perf.yaml
+++ b/deploy/pre-ngsa-asb-centralus/monitoring/grafana/dashboards/ngsa-az-monitor-perf.yaml
@@ -5208,7 +5208,7 @@ data:
           },
           "timepicker": {},
           "timezone": "browser",
-          "title": "NGSA Pre - Azure Monitor Performance",
+          "title": "NGSA - Azure Monitor Performance",
           "uid": "2IRD5FSnp",
           "version": 1
         }

--- a/deploy/pre-ngsa-asb-centralus/monitoring/grafana/dashboards/ngsa-az-monitor-rel.yaml
+++ b/deploy/pre-ngsa-asb-centralus/monitoring/grafana/dashboards/ngsa-az-monitor-rel.yaml
@@ -4287,7 +4287,7 @@ data:
           },
           "timepicker": {},
           "timezone": "browser",
-          "title": "NGSA Pre - Azure Monitor -  Reliability",
+          "title": "NGSA - Azure Monitor -  Reliability",
           "uid": "2IRD5FSnr",
           "version": 1
         }

--- a/deploy/pre-ngsa-asb-centralus/monitoring/grafana/dashboards/ngsa-fluentbit.yaml
+++ b/deploy/pre-ngsa-asb-centralus/monitoring/grafana/dashboards/ngsa-fluentbit.yaml
@@ -747,7 +747,7 @@ data:
             ]
           },
           "timezone": "",
-          "title": "NGSA Dev - Fluent Bit",
+          "title": "NGSA - Fluent Bit",
           "uid": "fluentbit",
           "version": 2,
           "weekStart": ""

--- a/deploy/pre-ngsa-asb-centralus/monitoring/grafana/dashboards/ngsa-prometheus.yaml
+++ b/deploy/pre-ngsa-asb-centralus/monitoring/grafana/dashboards/ngsa-prometheus.yaml
@@ -794,7 +794,7 @@ data:
           ]
         },
         "timezone": "",
-        "title": "NGSA Pre - Prometheus",
+        "title": "NGSA - Prometheus",
         "uid": "J20-83NHf",
         "version": 1
         }

--- a/deploy/pre-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-az-blocked-traffic.yaml
+++ b/deploy/pre-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-az-blocked-traffic.yaml
@@ -886,7 +886,7 @@ data:
           },
           "timepicker": {},
           "timezone": "",
-          "title": "NGSA Pre - Blocked Traffic",
+          "title": "NGSA - Blocked Traffic",
           "uid": "PpsPzW8nk",
           "version": 4
         }

--- a/deploy/pre-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-az-monitor-perf.yaml
+++ b/deploy/pre-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-az-monitor-perf.yaml
@@ -5208,7 +5208,7 @@ data:
           },
           "timepicker": {},
           "timezone": "browser",
-          "title": "NGSA Pre - Azure Monitor Performance",
+          "title": "NGSA - Azure Monitor Performance",
           "uid": "2IRD5FSnp",
           "version": 1
         }

--- a/deploy/pre-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-az-monitor-rel.yaml
+++ b/deploy/pre-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-az-monitor-rel.yaml
@@ -4287,7 +4287,7 @@ data:
           },
           "timepicker": {},
           "timezone": "browser",
-          "title": "NGSA Pre - Azure Monitor -  Reliability",
+          "title": "NGSA - Azure Monitor -  Reliability",
           "uid": "2IRD5FSnr",
           "version": 1
         }

--- a/deploy/pre-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-fluentbit.yaml
+++ b/deploy/pre-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-fluentbit.yaml
@@ -747,7 +747,7 @@ data:
             ]
           },
           "timezone": "",
-          "title": "NGSA Dev - Fluent Bit",
+          "title": "NGSA - Fluent Bit",
           "uid": "fluentbit",
           "version": 2,
           "weekStart": ""

--- a/deploy/pre-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-prometheus.yaml
+++ b/deploy/pre-ngsa-asb-eastus/monitoring/grafana/dashboards/ngsa-prometheus.yaml
@@ -794,7 +794,7 @@ data:
           ]
         },
         "timezone": "",
-        "title": "NGSA Pre - Prometheus",
+        "title": "NGSA - Prometheus",
         "uid": "J20-83NHf",
         "version": 1
         }

--- a/deploy/pre-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-az-monitor-perf.yaml
+++ b/deploy/pre-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-az-monitor-perf.yaml
@@ -5208,7 +5208,7 @@ data:
           },
           "timepicker": {},
           "timezone": "browser",
-          "title": "NGSA Pre - Azure Monitor Performance",
+          "title": "NGSA - Azure Monitor Performance",
           "uid": "2IRD5FSnp",
           "version": 1
         }

--- a/deploy/pre-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-az-monitor-rel.yaml
+++ b/deploy/pre-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-az-monitor-rel.yaml
@@ -4287,7 +4287,7 @@ data:
           },
           "timepicker": {},
           "timezone": "browser",
-          "title": "NGSA Pre - Azure Monitor -  Reliability",
+          "title": "NGSA - Azure Monitor -  Reliability",
           "uid": "2IRD5FSnr",
           "version": 1
         }

--- a/deploy/pre-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-fluentbit.yaml
+++ b/deploy/pre-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-fluentbit.yaml
@@ -747,7 +747,7 @@ data:
             ]
           },
           "timezone": "",
-          "title": "NGSA Dev - Fluent Bit",
+          "title": "NGSA - Fluent Bit",
           "uid": "fluentbit",
           "version": 2,
           "weekStart": ""

--- a/deploy/pre-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-prometheus.yaml
+++ b/deploy/pre-ngsa-asb-westus2/monitoring/grafana/dashboards/ngsa-prometheus.yaml
@@ -794,7 +794,7 @@ data:
           ]
         },
         "timezone": "",
-        "title": "NGSA Pre - Prometheus",
+        "title": "NGSA - Prometheus",
         "uid": "J20-83NHf",
         "version": 1
         }

--- a/monitoring/dashboards/ngsa-dev-model.json
+++ b/monitoring/dashboards/ngsa-dev-model.json
@@ -7318,7 +7318,7 @@
   },
   "timepicker": {},
   "timezone": "browser",
-  "title": "NGSA Dev - Azure Monitor",
+  "title": "NGSA - Azure Monitor",
   "uid": "2IRD5FSny",
   "version": 2
 }

--- a/monitoring/dashboards/ngsa-pre-model.json
+++ b/monitoring/dashboards/ngsa-pre-model.json
@@ -9407,7 +9407,7 @@ data:
           },
           "timepicker": {},
           "timezone": "browser",
-          "title": "NGSA Pre - Azure Monitor",
+          "title": "NGSA - Azure Monitor",
           "uid": "2IRD5FSnz",
           "version": 2
         }        


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [X] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## Purpose of PR

Make all Grafana dashboard titles generic, i.e. remove the dev/pre from title texts.

5 clusters x 5 dashboard files each = 25 files.

## Does this introduce a breaking change

- [ ] YES
- [X] NO
