### PR TITLE
Reduce app gateway alert uptime threshold

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -55,6 +55,10 @@ You'll need to run a few more steps to completely setup the AAD Service Principa
 2. If you haven't added the users already, go ahead and add them in the "Users and groups" menu from the sidebar.
 3. Go to "Properties", select "Yes" for the "Assignment required?" option and save. This ensures users only assigned to the Service Principal can access Grafana.
 
+### Setup Grafana deployment templates
+
+🛑 The current setup for Grafana uses the default sqlite database for storage. In order to run multiple pods, a shared storage setup should be investigated. With this constraint, Grafana should only have 1 replica. More information here <https://grafana.com/docs/grafana/latest/setup-grafana/set-up-for-high-availability>.
+
 ```bash
 
 # Optional: Add client secret using AZ CLI

--- a/monitoring/alerts/metricsAlerts/dev/asb-dev-eastus-AppEndpointDown.json
+++ b/monitoring/alerts/metricsAlerts/dev/asb-dev-eastus-AppEndpointDown.json
@@ -13,7 +13,7 @@
         "criteria": {
             "allOf": [
                 {
-                    "threshold": 1,
+                    "threshold": 0.99,
                     "name": "Metric1",
                     "metricNamespace": "Microsoft.Network/applicationGateways",
                     "metricName": "HealthyHostCount",

--- a/monitoring/alerts/metricsAlerts/dev/asb-dev-westus2-AppEndpointDown.json
+++ b/monitoring/alerts/metricsAlerts/dev/asb-dev-westus2-AppEndpointDown.json
@@ -13,7 +13,7 @@
         "criteria": {
             "allOf": [
                 {
-                    "threshold": 1,
+                    "threshold": 0.99,
                     "name": "Metric1",
                     "metricNamespace": "Microsoft.Network/applicationGateways",
                     "metricName": "HealthyHostCount",

--- a/monitoring/alerts/metricsAlerts/pre/asb-pre-centralus-AppEndpointDown.json
+++ b/monitoring/alerts/metricsAlerts/pre/asb-pre-centralus-AppEndpointDown.json
@@ -13,7 +13,7 @@
         "criteria": {
             "allOf": [
                 {
-                    "threshold": 1,
+                    "threshold": 0.99,
                     "name": "Metric1",
                     "metricNamespace": "Microsoft.Network/applicationGateways",
                     "metricName": "HealthyHostCount",

--- a/monitoring/alerts/metricsAlerts/pre/asb-pre-eastus-AppEndpointDown.json
+++ b/monitoring/alerts/metricsAlerts/pre/asb-pre-eastus-AppEndpointDown.json
@@ -13,7 +13,7 @@
         "criteria": {
             "allOf": [
                 {
-                    "threshold": 1,
+                    "threshold": 0.99,
                     "name": "Metric1",
                     "metricNamespace": "Microsoft.Network/applicationGateways",
                     "metricName": "HealthyHostCount",

--- a/monitoring/alerts/metricsAlerts/pre/asb-pre-westus2-AppEndpointDown.json
+++ b/monitoring/alerts/metricsAlerts/pre/asb-pre-westus2-AppEndpointDown.json
@@ -13,7 +13,7 @@
         "criteria": {
             "allOf": [
                 {
-                    "threshold": 1,
+                    "threshold": 0.99,
                     "name": "Metric1",
                     "metricNamespace": "Microsoft.Network/applicationGateways",
                     "metricName": "HealthyHostCount",


### PR DESCRIPTION
# Type of PR

- [x] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [x] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR

- Reduce App Gateway alert threshold to allow for some downtime and reduce alert frequency
- Add a note about Grafana replica count limitation

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Validation

- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/945
- References https://github.com/retaildevcrews/wcnp/issues/722
