### PR TITLE
Migrate from `static_config` to `k8s_sd_config` for prometheus metrics

### DIFF
--- a/deploy/dev-ngsa-asb-eastus/monitoring/02-prometheus.yaml
+++ b/deploy/dev-ngsa-asb-eastus/monitoring/02-prometheus.yaml
@@ -83,19 +83,67 @@ data:
     global:
       scrape_interval: 15s
       evaluation_interval: 15s
-    scrape_configs:      
+    scrape_configs:
       - job_name: 'ngsa-memory'
-        static_configs:
-          - targets: [ 'ngsa-memory.ngsa.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-memory"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'ngsa-cosmos'
-        static_configs:
-          - targets: [ 'ngsa-cosmos.ngsa.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-cosmos"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'ngsa-java'
-        static_configs:
-          - targets: [ 'ngsa-java.ngsa.svc.cluster.local:8080' ]
-      - job_name: 'loderunner'
-        static_configs:
-          - targets: [ 'loderunner.loderunner.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-java"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
+      - job_name: 'loderunner-commandmode'
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - loderunner
+          selectors:
+            - role: "pod"
+              label: "app=loderunner"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'fluentbit'
         metrics_path: /api/v1/metrics/prometheus
         kubernetes_sd_configs:

--- a/deploy/dev-ngsa-asb-westus2/monitoring/02-prometheus.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/02-prometheus.yaml
@@ -83,19 +83,67 @@ data:
     global:
       scrape_interval: 15s
       evaluation_interval: 15s
-    scrape_configs:      
+    scrape_configs:
       - job_name: 'ngsa-memory'
-        static_configs:
-          - targets: [ 'ngsa-memory.ngsa.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-memory"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'ngsa-cosmos'
-        static_configs:
-          - targets: [ 'ngsa-cosmos.ngsa.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-cosmos"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'ngsa-java'
-        static_configs:
-          - targets: [ 'ngsa-java.ngsa.svc.cluster.local:8080' ]
-      - job_name: 'loderunner'
-        static_configs:
-          - targets: [ 'loderunner.loderunner.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-java"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
+      - job_name: 'loderunner-commandmode'
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - loderunner
+          selectors:
+            - role: "pod"
+              label: "app=loderunner"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'fluentbit'
         metrics_path: /api/v1/metrics/prometheus
         kubernetes_sd_configs:

--- a/deploy/pre-ngsa-asb-centralus/monitoring/02-prometheus.yaml
+++ b/deploy/pre-ngsa-asb-centralus/monitoring/02-prometheus.yaml
@@ -83,19 +83,67 @@ data:
     global:
       scrape_interval: 15s
       evaluation_interval: 15s
-    scrape_configs:      
+    scrape_configs:
       - job_name: 'ngsa-memory'
-        static_configs:
-          - targets: [ 'ngsa-memory.ngsa.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-memory"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'ngsa-cosmos'
-        static_configs:
-          - targets: [ 'ngsa-cosmos.ngsa.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-cosmos"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'ngsa-java'
-        static_configs:
-          - targets: [ 'ngsa-java.ngsa.svc.cluster.local:8080' ]
-      - job_name: 'loderunner'
-        static_configs:
-          - targets: [ 'loderunner.loderunner.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-java"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
+      - job_name: 'loderunner-commandmode'
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - loderunner
+          selectors:
+            - role: "pod"
+              label: "app=loderunner"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'fluentbit'
         metrics_path: /api/v1/metrics/prometheus
         kubernetes_sd_configs:

--- a/deploy/pre-ngsa-asb-eastus/monitoring/02-prometheus.yaml
+++ b/deploy/pre-ngsa-asb-eastus/monitoring/02-prometheus.yaml
@@ -83,19 +83,67 @@ data:
     global:
       scrape_interval: 15s
       evaluation_interval: 15s
-    scrape_configs:      
+    scrape_configs:
       - job_name: 'ngsa-memory'
-        static_configs:
-          - targets: [ 'ngsa-memory.ngsa.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-memory"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'ngsa-cosmos'
-        static_configs:
-          - targets: [ 'ngsa-cosmos.ngsa.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-cosmos"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'ngsa-java'
-        static_configs:
-          - targets: [ 'ngsa-java.ngsa.svc.cluster.local:8080' ]
-      - job_name: 'loderunner'
-        static_configs:
-          - targets: [ 'loderunner.loderunner.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-java"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
+      - job_name: 'loderunner-commandmode'
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - loderunner
+          selectors:
+            - role: "pod"
+              label: "app=loderunner"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'fluentbit'
         metrics_path: /api/v1/metrics/prometheus
         kubernetes_sd_configs:

--- a/deploy/pre-ngsa-asb-westus2/monitoring/02-prometheus.yaml
+++ b/deploy/pre-ngsa-asb-westus2/monitoring/02-prometheus.yaml
@@ -83,19 +83,67 @@ data:
     global:
       scrape_interval: 15s
       evaluation_interval: 15s
-    scrape_configs:      
+    scrape_configs:
       - job_name: 'ngsa-memory'
-        static_configs:
-          - targets: [ 'ngsa-memory.ngsa.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-memory"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'ngsa-cosmos'
-        static_configs:
-          - targets: [ 'ngsa-cosmos.ngsa.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-cosmos"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'ngsa-java'
-        static_configs:
-          - targets: [ 'ngsa-java.ngsa.svc.cluster.local:8080' ]
-      - job_name: 'loderunner'
-        static_configs:
-          - targets: [ 'loderunner.loderunner.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-java"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
+      - job_name: 'loderunner-commandmode'
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - loderunner
+          selectors:
+            - role: "pod"
+              label: "app=loderunner"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'fluentbit'
         metrics_path: /api/v1/metrics/prometheus
         kubernetes_sd_configs:

--- a/templates/monitoring/02-prometheus.yaml
+++ b/templates/monitoring/02-prometheus.yaml
@@ -83,19 +83,82 @@ data:
     global:
       scrape_interval: 15s
       evaluation_interval: 15s
-    scrape_configs:      
+    scrape_configs:
       - job_name: 'ngsa-memory'
-        static_configs:
-          - targets: [ 'ngsa-memory.ngsa.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-memory"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'ngsa-cosmos'
-        static_configs:
-          - targets: [ 'ngsa-cosmos.ngsa.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-cosmos"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
       - job_name: 'ngsa-java'
-        static_configs:
-          - targets: [ 'ngsa-java.ngsa.svc.cluster.local:8080' ]
-      - job_name: 'loderunner'
-        static_configs:
-          - targets: [ 'loderunner.loderunner.svc.cluster.local:8080' ]
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - ngsa
+          selectors:
+            - role: "pod"
+              label: "app=ngsa-java"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
+      - job_name: 'loderunner-commandmode'
+        metrics_path: /metrics
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - loderunner
+          selectors:
+            - role: "pod"
+              label: "app=loderunner"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
+      - job_name: 'fluentbit'
+        metrics_path: /api/v1/metrics/prometheus
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - fluentbit
+          selectors:
+            - role: "pod"
+              label: "app.kubernetes.io/name=fluentbit"
+              field: "status.phase=Running"
+        relabel_configs:
+        - source_labels: [ __meta_kubernetes_pod_name ]
+          action: replace
+          target_label: instance
 
 ---
 


### PR DESCRIPTION
# Type of PR

- [X] Code changes

## Purpose of PR
Migrate prometheus config of NGSA apps from `static_config` to `kubernetes_sd_config` so that prometheus can capture individual pod's metrics.

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Validation

- [ ] Tested after deploying to EastUS dev cluster

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/932