### PR TITLE
Pragmatical/addkubelogin

### DIFF
--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -30,10 +30,10 @@ sudo mv ./clusterctl /usr/local/bin/clusterctl
 
 # install kubelogin
 wget https://github.com/Azure/kubelogin/releases/download/v0.0.20/kubelogin-linux-amd64.zip
-unzip -p kubelogin-linux-amd64.zip bin/linux_amd64/kubelogin > kubelogin
-chmod +x kubelogin
-sudo mv kubelogin /usr/local/bin/kubelogin
-rm kubelogin-linux-amd64.zip
+unzip -p ./kubelogin-linux-amd64.zip bin/linux_amd64/kubelogin > kubelogin
+chmod +x ./kubelogin
+sudo mv ./kubelogin /usr/local/bin/kubelogin
+rm ./kubelogin-linux-amd64.zip
 
 # install latest flux in ~/.local/bin
 curl -s https://fluxcd.io/install.sh |  bash -s - ~/.local/bin

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -42,4 +42,4 @@ echo '. <(flux completion bash)' >> ~/.bashrc
 # install flux completions for zsh
 echo '. <(flux completion zsh)' >> ~/.zshrc
 
-echo "on-create completed" > $HOME/status
+echo "on-create completed" >> $HOME/status

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -24,16 +24,20 @@ k3d registry create registry.localhost --port 5000
 docker network connect k3d k3d-registry.localhost
 
 # install clusterctl (Cluster API)
+echo "  install clusterctl" >> $HOME/status
 curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.5/clusterctl-linux-amd64 -o clusterctl
 chmod +x ./clusterctl
 sudo mv ./clusterctl /usr/local/bin/clusterctl
+echo "  install clusterctl done" >> $HOME/status
 
 # install kubelogin
+echo "  install kubelogin" >> $HOME/status
 wget https://github.com/Azure/kubelogin/releases/download/v0.0.20/kubelogin-linux-amd64.zip
 unzip -p kubelogin-linux-amd64.zip bin/linux_amd64/kubelogin > kubelogin
 chmod +x kubelogin
 sudo mv kubelogin /usr/local/bin/kubelogin
 rm kubelogin-linux-amd64.zip
+echo "  install kubelogin done" >> $HOME/status
 
 # install latest flux in ~/.local/bin
 curl -s https://fluxcd.io/install.sh |  bash -s - ~/.local/bin
@@ -42,4 +46,4 @@ echo '. <(flux completion bash)' >> ~/.bashrc
 # install flux completions for zsh
 echo '. <(flux completion zsh)' >> ~/.zshrc
 
-echo "on-create completed" > $HOME/status
+echo "on-create completed" >> $HOME/status

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -30,11 +30,10 @@ sudo mv ./clusterctl /usr/local/bin/clusterctl
 
 # install kubelogin
 wget https://github.com/Azure/kubelogin/releases/download/v0.0.20/kubelogin-linux-amd64.zip
-unzip ./kubelogin-linux-amd64.zip 
-chmod +x ./bin/linux_amd64/kubelogin
-sudo mv ./bin/linux_amd64/kubelogin /usr/local/bin/kubelogin
-rm ./kubelogin-linux-amd64.zip
-kubelogin --version >> $HOME/status
+unzip -p kubelogin-linux-amd64.zip bin/linux_amd64/kubelogin > kubelogin
+chmod +x kubelogin
+sudo mv kubelogin /usr/local/bin/kubelogin
+rm kubelogin-linux-amd64.zip
 
 # install latest flux in ~/.local/bin
 curl -s https://fluxcd.io/install.sh |  bash -s - ~/.local/bin
@@ -43,4 +42,4 @@ echo '. <(flux completion bash)' >> ~/.bashrc
 # install flux completions for zsh
 echo '. <(flux completion zsh)' >> ~/.zshrc
 
-echo "on-create completed" >> $HOME/status
+echo "on-create completed" > $HOME/status

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -24,20 +24,16 @@ k3d registry create registry.localhost --port 5000
 docker network connect k3d k3d-registry.localhost
 
 # install clusterctl (Cluster API)
-echo "  install clusterctl" >> $HOME/status
 curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.5/clusterctl-linux-amd64 -o clusterctl
 chmod +x ./clusterctl
 sudo mv ./clusterctl /usr/local/bin/clusterctl
-echo "  install clusterctl done" >> $HOME/status
 
 # install kubelogin
-echo "  install kubelogin" >> $HOME/status
 wget https://github.com/Azure/kubelogin/releases/download/v0.0.20/kubelogin-linux-amd64.zip
 unzip -p kubelogin-linux-amd64.zip bin/linux_amd64/kubelogin > kubelogin
 chmod +x kubelogin
 sudo mv kubelogin /usr/local/bin/kubelogin
 rm kubelogin-linux-amd64.zip
-echo "  install kubelogin done" >> $HOME/status
 
 # install latest flux in ~/.local/bin
 curl -s https://fluxcd.io/install.sh |  bash -s - ~/.local/bin
@@ -46,4 +42,4 @@ echo '. <(flux completion bash)' >> ~/.bashrc
 # install flux completions for zsh
 echo '. <(flux completion zsh)' >> ~/.zshrc
 
-echo "on-create completed" >> $HOME/status
+echo "on-create completed" > $HOME/status

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -28,6 +28,13 @@ curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.5/
 chmod +x ./clusterctl
 sudo mv ./clusterctl /usr/local/bin/clusterctl
 
+# install kubelogin
+wget https://github.com/Azure/kubelogin/releases/download/v0.0.20/kubelogin-linux-amd64.zip
+unzip -p kubelogin-linux-amd64.zip bin/linux_amd64/kubelogin > kubelogin
+chmod +x kubelogin
+sudo mv kubelogin /usr/local/bin/kubelogin
+rm kubelogin-linux-amd64.zip
+
 # install latest flux in ~/.local/bin
 curl -s https://fluxcd.io/install.sh |  bash -s - ~/.local/bin
 # install flux completions for bash

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -30,10 +30,11 @@ sudo mv ./clusterctl /usr/local/bin/clusterctl
 
 # install kubelogin
 wget https://github.com/Azure/kubelogin/releases/download/v0.0.20/kubelogin-linux-amd64.zip
-unzip -p ./kubelogin-linux-amd64.zip bin/linux_amd64/kubelogin > kubelogin
-chmod +x ./kubelogin
-sudo mv ./kubelogin /usr/local/bin/kubelogin
+unzip ./kubelogin-linux-amd64.zip 
+chmod +x ./bin/linux_amd64/kubelogin
+sudo mv ./bin/linux_amd64/kubelogin /usr/local/bin/kubelogin
 rm ./kubelogin-linux-amd64.zip
+kubelogin --version >> $HOME/status
 
 # install latest flux in ~/.local/bin
 curl -s https://fluxcd.io/install.sh |  bash -s - ~/.local/bin
@@ -42,4 +43,4 @@ echo '. <(flux completion bash)' >> ~/.bashrc
 # install flux completions for zsh
 echo '. <(flux completion zsh)' >> ~/.zshrc
 
-echo "on-create completed" > $HOME/status
+echo "on-create completed" >> $HOME/status

--- a/README.md
+++ b/README.md
@@ -296,6 +296,9 @@ export ASB_AKS_NAME=$(az deployment group show -g $ASB_RG_CORE -n cluster-${ASB_
 # Get AKS credentials
 az aks get-credentials -g $ASB_RG_CORE -n $ASB_AKS_NAME
 
+# Authenticate Kubectl
+kubelogin convert-kubeconfig -l azurecli
+
 # Rename context for simplicity
 kubectl config rename-context $ASB_AKS_NAME $ASB_DEPLOYMENT_NAME-${ASB_CLUSTER_LOCATION}
 


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [ ] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [X] Codespace changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
Making Kubelogin available for ngsa codespace.  This is necessary moving forward in order to use kubectl/k9s.  Prior authentication mechanism is being deprecated and new fpdo directory will require authentication mechanism that does not require 2FA.   

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Validation

- [X] To validate this item create codespace from this branch, then run kubelogin.  Due to some issues with pre-build codespaces, there may be a need to rebuild the codespace container if kubelogin is not found the first time.  This will be resolves with the prebuild workflow runs on main.


## Issues Closed or Referenced

- Closes #1027