### PR TITLE
Bugfix: istio kustomize bug

### DIFF
--- a/deploy/dev-ngsa-asb-eastus/istio/kustomization.yaml
+++ b/deploy/dev-ngsa-asb-eastus/istio/kustomization.yaml
@@ -9,7 +9,6 @@ patches:
           path: "/spec/servers/0/hosts"
           value: 
             - "ngsa/ngsa-memory-eastus-dev.cse.ms"
-            - "ngsa/ngsa-memory-eastus-dev.cse.ms"
             - "ngsa/ngsa-cosmos-eastus-dev.cse.ms"
             - "ngsa/ngsa-java-eastus-dev.cse.ms"
             - "monitoring/grafana-eastus-dev.cse.ms"
@@ -17,12 +16,11 @@ patches:
             - "harbor/harbor-core-eastus-dev.cse.ms"
 
         - op: add
-          path: "/spec/servers/0"
-          value: 
-            tls:
-              mode: SIMPLE
-              serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
-              privateKey: /etc/istio/ingressgateway-certs/tls.key            
+          path: "/spec/servers/0/tls"
+          value:
+            mode: SIMPLE
+            serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
+            privateKey: /etc/istio/ingressgateway-certs/tls.key            
     target:
       kind: Gateway
       name: istio-gateway

--- a/deploy/dev-ngsa-asb-eastus/istio/kustomization.yaml
+++ b/deploy/dev-ngsa-asb-eastus/istio/kustomization.yaml
@@ -20,7 +20,7 @@ patches:
           value:
             mode: SIMPLE
             serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
-            privateKey: /etc/istio/ingressgateway-certs/tls.key            
+            privateKey: /etc/istio/ingressgateway-certs/tls.key
     target:
       kind: Gateway
       name: istio-gateway

--- a/deploy/dev-ngsa-asb-westus2/istio/kustomization.yaml
+++ b/deploy/dev-ngsa-asb-westus2/istio/kustomization.yaml
@@ -15,12 +15,11 @@ patches:
             - "loderunner/loderunner-westus2-dev.cse.ms"
 
         - op: add
-          path: "/spec/servers/0"
-          value: 
-            tls:
-              mode: SIMPLE
-              serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
-              privateKey: /etc/istio/ingressgateway-certs/tls.key            
+          path: "/spec/servers/0/tls"
+          value:
+            mode: SIMPLE
+            serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
+            privateKey: /etc/istio/ingressgateway-certs/tls.key
     target:
       kind: Gateway
       name: istio-gateway

--- a/deploy/pre-ngsa-asb-centralus/istio/kustomization.yaml
+++ b/deploy/pre-ngsa-asb-centralus/istio/kustomization.yaml
@@ -15,12 +15,11 @@ patches:
           - "loderunner/loderunner-centralus-pre.cse.ms"            
 
         - op: add
-          path: "/spec/servers/0"
-          value: 
-            tls:
-              mode: SIMPLE
-              serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
-              privateKey: /etc/istio/ingressgateway-certs/tls.key            
+          path: "/spec/servers/0/tls"
+          value:
+            mode: SIMPLE
+            serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
+            privateKey: /etc/istio/ingressgateway-certs/tls.key
     target:
       kind: Gateway
       name: istio-gateway

--- a/deploy/pre-ngsa-asb-eastus/istio/kustomization.yaml
+++ b/deploy/pre-ngsa-asb-eastus/istio/kustomization.yaml
@@ -14,12 +14,11 @@ patches:
           - "monitoring/grafana-eastus-pre.cse.ms"
 
         - op: add
-          path: "/spec/servers/0"
-          value: 
-            tls:
-              mode: SIMPLE
-              serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
-              privateKey: /etc/istio/ingressgateway-certs/tls.key            
+          path: "/spec/servers/0/tls"
+          value:
+            mode: SIMPLE
+            serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
+            privateKey: /etc/istio/ingressgateway-certs/tls.key
     target:
       kind: Gateway
       name: istio-gateway

--- a/deploy/pre-ngsa-asb-westus2/istio/kustomization.yaml
+++ b/deploy/pre-ngsa-asb-westus2/istio/kustomization.yaml
@@ -14,12 +14,11 @@ patches:
           - "monitoring/grafana-westus2-pre.cse.ms"
 
         - op: add
-          path: "/spec/servers/0"
-          value: 
-            tls:
-              mode: SIMPLE
-              serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
-              privateKey: /etc/istio/ingressgateway-certs/tls.key            
+          path: "/spec/servers/0/tls"
+          value:
+            mode: SIMPLE
+            serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
+            privateKey: /etc/istio/ingressgateway-certs/tls.key
     target:
       kind: Gateway
       name: istio-gateway

--- a/flux-init/base/gotk-repo.yaml
+++ b/flux-init/base/gotk-repo.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: bugfix/istio-kustomize
+    branch: main
   # secretRef: # We're accessing ngs-asb as readonly repo
   #   name: flux-system
   url: https://github.com/retaildevcrews/ngsa-asb

--- a/flux-init/base/gotk-repo.yaml
+++ b/flux-init/base/gotk-repo.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: bugfix/istio-kustomize
   # secretRef: # We're accessing ngs-asb as readonly repo
   #   name: flux-system
   url: https://github.com/retaildevcrews/ngsa-asb


### PR DESCRIPTION
# Type of PR

- [X] Code changes

## PR Checklist

- [X] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [X] I ran lint checks locally prior to submission.
- [X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
Fix a kustomize issue on istio gateway.
Upon reconciliation the kustomization would generate a new array `tls` under `.spec.server`.
The fix was tested in EastUS Dev cluster and existing tests passing without any reconciliation error.

### Expected YAML:
```yaml
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: istio-gateway
  namespace: istio-system
spec:
  selector:
    istio: ingressgateway
  servers:
  - tls:
      mode: SIMPLE
      privateKey: /etc/istio/ingressgateway-certs/tls.key
      serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
    hosts:
    - ngsa/ngsa-memory-eastus-dev.cse.ms
    - ngsa/ngsa-cosmos-eastus-dev.cse.ms
    - ngsa/ngsa-java-eastus-dev.cse.ms
    - monitoring/grafana-eastus-dev.cse.ms
    - loderunner/loderunner-eastus-dev.cse.ms
    - harbor/harbor-core-eastus-dev.cse.ms
    port:
      name: https
      number: 443
      protocol: HTTPS
```

### Generated YAML
```yaml
apiVersion: networking.istio.io/v1alpha3
kind: Gateway
metadata:
  name: istio-gateway
  namespace: istio-system
spec:
  selector:
    istio: ingressgateway
  servers:
  - tls:  #### <-- This one should be under array item 0, in the same object as hosts and ports below
      mode: SIMPLE
      privateKey: /etc/istio/ingressgateway-certs/tls.key
      serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
  - hosts:
    - ngsa/ngsa-memory-eastus-dev.cse.ms
    - ngsa/ngsa-memory-eastus-dev.cse.ms
    - ngsa/ngsa-cosmos-eastus-dev.cse.ms
    - ngsa/ngsa-java-eastus-dev.cse.ms
    - monitoring/grafana-eastus-dev.cse.ms
    - loderunner/loderunner-eastus-dev.cse.ms
    - harbor/harbor-core-eastus-dev.cse.ms
    port:
      name: https
      number: 443
      protocol: HTTPS
```

## Does this introduce a breaking change

- [X] YES
- [ ] NO


## Validation

- [X] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/1043