### PR TITLE
Increase Max Pods Per Node

### DIFF
--- a/cluster/cluster-stamp-additional.json
+++ b/cluster/cluster-stamp-additional.json
@@ -286,7 +286,7 @@
                         "scaleSetEvictionPolicy": "Delete",
                         "orchestratorVersion": "[parameters('kubernetesVersion')]",
                         "enableNodePublicIP": false,
-                        "maxPods": 30,
+                        "maxPods": 100,
                         "availabilityZones": [
                             "1",
                             "2",
@@ -313,7 +313,7 @@
                         "scaleSetEvictionPolicy": "Delete",
                         "orchestratorVersion": "[parameters('kubernetesVersion')]",
                         "enableNodePublicIP": false,
-                        "maxPods": 30,
+                        "maxPods": 100,
                         "availabilityZones": [
                             "1",
                             "2",

--- a/cluster/cluster-stamp.json
+++ b/cluster/cluster-stamp.json
@@ -1215,7 +1215,7 @@
                         "scaleSetEvictionPolicy": "Delete",
                         "orchestratorVersion": "[parameters('kubernetesVersion')]",
                         "enableNodePublicIP": false,
-                        "maxPods": 30,
+                        "maxPods": 100,
                         "availabilityZones": [
                             "1",
                             "2",
@@ -1242,7 +1242,7 @@
                         "scaleSetEvictionPolicy": "Delete",
                         "orchestratorVersion": "[parameters('kubernetesVersion')]",
                         "enableNodePublicIP": false,
-                        "maxPods": 30,
+                        "maxPods": 100,
                         "availabilityZones": [
                             "1",
                             "2",

--- a/spikes/cilium/cluster-stamp.json
+++ b/spikes/cilium/cluster-stamp.json
@@ -1223,7 +1223,7 @@
                         "scaleSetEvictionPolicy": "Delete",
                         "orchestratorVersion": "[parameters('kubernetesVersion')]",
                         "enableNodePublicIP": false,
-                        "maxPods": 30,
+                        "maxPods": 100,
                         "availabilityZones": [
                             "1",
                             "2",
@@ -1250,7 +1250,7 @@
                         "scaleSetEvictionPolicy": "Delete",
                         "orchestratorVersion": "[parameters('kubernetesVersion')]",
                         "enableNodePublicIP": false,
-                        "maxPods": 30,
+                        "maxPods": 100,
                         "availabilityZones": [
                             "1",
                             "2",


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [ ] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
After pod utilization bash, we starting hitting pod scheduling bottlenecks due to max number of pods allowed per node pool. Most CNI plugins have defaults of over 100 so increasing for our setup should not be a problem.

The goals is to have this change only reflected on new clusters and not existing ones.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Validation

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/1035
