### PR TITLE
Add realtime metrics support to Thanos deployments

### DIFF
--- a/cluster/cluster-stamp.json
+++ b/cluster/cluster-stamp.json
@@ -1321,7 +1321,7 @@
                     "authorizedIPRanges": "[parameters('clusterAuthorizedIPRanges')]",
                     "enablePrivateCluster": false
                 },
-                "podIdentityProfile": { 
+                "podIdentityProfile": {
                     "enabled": false, /* This feature is currently in preview and will eventually replace the aad-pod-identity configuration set up by hand in this reference implementation */
                     "userAssignedIdentities": [],
                     "userAssignedIdentityExceptions": []
@@ -2104,7 +2104,7 @@
                         "value": "1000m"
                     },
                     "memoryLimit": {
-                        "value": "512Mi"
+                        "value": "1024Mi"
                     },
                     "excludedNamespaces": {
                         "value": [

--- a/deploy/base/apps/monitoring/prometheus/02-prometheus.yaml
+++ b/deploy/base/apps/monitoring/prometheus/02-prometheus.yaml
@@ -105,6 +105,10 @@ spec:
             - "--storage.tsdb.retention.size=3900MB"
             - "--storage.tsdb.retention.time=7d"
             - "--enable-feature=expand-external-labels" # for env substitution of external lables in cm
+            - "--storage.tsdb.min-block-duration=2h"
+            - "--storage.tsdb.max-block-duration=2h"
+            - "--web.enable-lifecycle"
+            - "--web.enable-admin-api"
           env:
           - name: PROM_EXT_LABEL_CLUSTER
             value: base
@@ -143,6 +147,52 @@ spec:
             capabilities:
               drop:
                 - ALL
+        - name: thanos
+          image: quay.io/thanos/thanos:v0.23.0
+          imagePullPolicy: Always
+          args:
+            - "sidecar"
+            - "--log.level=debug"
+            - "--tsdb.path=/prometheus/"
+            - "--prometheus.url=http://localhost:9090"
+            - "--objstore.config-file=/etc/secret/thanos-storage-config.yaml"
+            - "--reloader.config-file=/etc/prometheus/prometheus.yml"
+          env:
+            - name : THANOS_OBJSTORE_CONFIG
+              value: /etc/secret/thanos-storage-config.yaml
+          ports:
+            - name: http-sidecar
+              containerPort: 10902
+            - name: grpc
+              containerPort: 10901
+          resources:
+            requests:
+              cpu: '100m'
+              memory: '64Mi'
+            limits:
+              cpu: '250m'
+              memory: '256Mi'
+          livenessProbe:
+              httpGet:
+                port: 10902
+                path: /-/healthy
+          readinessProbe:
+            httpGet:
+              port: 10902
+              path: /-/ready
+          volumeMounts:
+            - name: prometheus-storage-volume
+              mountPath: /prometheus
+            - name: prometheus-config-volume
+              mountPath: /etc/prometheus
+            - name: thanos-objstore-config
+              mountPath: /etc/secret
+              readOnly: false
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -158,6 +208,12 @@ spec:
         - name: prometheus-storage-volume
           persistentVolumeClaim:
             claimName: prometheus-pvc
+        - name: prometheus-config-shared
+          emptyDir: {}
+        - name: thanos-objstore-config
+          secret:
+            secretName: thanos-objstore-config
+
 ---
 
 apiVersion: v1
@@ -177,3 +233,28 @@ spec:
       port: 9090
       protocol: TCP
       targetPort: 9090
+    - name: grpc
+      port: 10901
+      targetPort: 10901
+    - name: http-sidecar
+      port: 10902
+      targetPort: 10902
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: thanos-grpc-vs
+  namespace: monitoring
+spec:
+  gateways:
+  - istio-system/istio-gateway
+  hosts:
+  - "*"
+  http:
+  - route:
+    - destination:
+        port:
+          number: 10901
+        host: prometheus-server

--- a/deploy/base/apps/monitoring/thanos/thanos-compactor.yaml
+++ b/deploy/base/apps/monitoring/thanos/thanos-compactor.yaml
@@ -32,11 +32,11 @@ spec:
               containerPort: 10902
           resources:
             requests:
-              cpu: '100m'
-              memory: '64Mi'
+              cpu: '500m'
+              memory: '512Mi'
             limits:
-              cpu: '250m'
-              memory: '256Mi'
+              cpu: '1000m'
+              memory: '1024Mi'
           livenessProbe:
               httpGet:
                 port: 10902

--- a/deploy/base/apps/monitoring/thanos/thanos-store.yaml
+++ b/deploy/base/apps/monitoring/thanos/thanos-store.yaml
@@ -41,11 +41,11 @@ spec:
               containerPort: 10900
           resources:
             requests:
-              cpu: '100m'
-              memory: '64Mi'
+              cpu: '500m'
+              memory: '512Mi'
             limits:
-              cpu: '250m'
-              memory: '256Mi'
+              cpu: '1000m'
+              memory: '1024Mi'
           livenessProbe:
               httpGet:
                 port: 10902
@@ -98,3 +98,22 @@ spec:
     targetPort: 10902
   selector:
     app.kubernetes.io/name: thanos-store
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: thanos-store-grpc-vs
+  namespace: monitoring
+spec:
+  gateways:
+  - istio-system/istio-gateway
+  hosts:
+  - "*"
+  http:
+  - route:
+    - destination:
+        port:
+          number: 10901
+        host: thanos-store

--- a/deploy/dev-ngsa-asb-eastus/istio/kustomization.yaml
+++ b/deploy/dev-ngsa-asb-eastus/istio/kustomization.yaml
@@ -7,11 +7,13 @@ patches:
   - patch: |
         - op: replace
           path: "/spec/servers/0/hosts"
-          value: 
+          value:
             - "ngsa/ngsa-memory-eastus-dev.cse.ms"
             - "ngsa/ngsa-cosmos-eastus-dev.cse.ms"
             - "ngsa/ngsa-java-eastus-dev.cse.ms"
             - "monitoring/grafana-eastus-dev.cse.ms"
+            - "monitoring/thanos-grpc-eastus-dev.cse.ms"
+            - "monitoring/thanos-store-grpc-eastus-dev.cse.ms"
             - "loderunner/loderunner-eastus-dev.cse.ms"
             - "harbor/harbor-core-eastus-dev.cse.ms"
 
@@ -33,11 +35,11 @@ patches:
 
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/resources/requests/cpu"
-          value: 500m  
+          value: 500m
 
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/resources/requests/memory"
-          value: 256M  
+          value: 256M
 
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/service/loadBalancerIP"
@@ -45,7 +47,7 @@ patches:
 
         - op: add
           path: "/spec/meshConfig"
-          value: 
+          value:
             accessLogEncoding: JSON
             accessLogFile: "/dev/stdout"
             accessLogFormat: |
@@ -98,7 +100,7 @@ patches:
   - patch: |
         - op: replace
           path: "/spec/parameters/keyvaultName"
-          value: "kv-aks-3i2qzkkxofr7c"   
+          value: "kv-aks-3i2qzkkxofr7c"
     target:
       kind: SecretProviderClass
       name: istio-ingress-tls-secret-csi-akv

--- a/deploy/dev-ngsa-asb-eastus/monitoring/prometheus/prometheus-patch.yaml
+++ b/deploy/dev-ngsa-asb-eastus/monitoring/prometheus/prometheus-patch.yaml
@@ -6,88 +6,22 @@ metadata:
 spec:
   template:
     spec:
-      volumes:
-      - name: prometheus-config-shared
-        emptyDir: {}
-      - name: thanos-objstore-config
-        secret:
-          secretName: thanos-objstore-config
       containers:
       - name: prometheus
         image: acraks3i2qzkkxofr7c.azurecr.io/prom/prometheus:v2.30.0
-        args:
-        # Base args
-        - "--config.file=/etc/prometheus/prometheus.yml"
-        - "--storage.tsdb.path=/prometheus/"
-        - "--storage.tsdb.retention.size=3900MB"
-        - "--storage.tsdb.retention.time=7d"
-        - "--enable-feature=expand-external-labels" # for env substitution of external lables in cm
-        # Below args added for thanos
-        - "--storage.tsdb.min-block-duration=2h"
-        - "--storage.tsdb.max-block-duration=2h"
-        - "--web.enable-lifecycle"
-        - "--web.enable-admin-api"
         env:
           - name: PROM_EXT_LABEL_CLUSTER
             value: aks-3i2qzkkxofr7c-eastus
       - name: thanos
         image: acraks3i2qzkkxofr7c.azurecr.io/thanos/thanos:v0.23.0
-        imagePullPolicy: Always
-        args:
-          - "sidecar"
-          - "--log.level=debug"
-          - "--tsdb.path=/prometheus/"
-          - "--prometheus.url=http://localhost:9090"
-          - "--objstore.config-file=/etc/secret/thanos-storage-config.yaml"
-          - "--reloader.config-file=/etc/prometheus/prometheus.yml"
-        env:
-          - name : THANOS_OBJSTORE_CONFIG
-            value: /etc/secret/thanos-storage-config.yaml
-        ports:
-          - name: http-sidecar
-            containerPort: 10902
-          - name: grpc
-            containerPort: 10901
-        resources:
-          requests:
-            cpu: '100m'
-            memory: '64Mi'
-          limits:
-            cpu: '250m'
-            memory: '256Mi'
-        livenessProbe:
-            httpGet:
-              port: 10902
-              path: /-/healthy
-        readinessProbe:
-          httpGet:
-            port: 10902
-            path: /-/ready
-        volumeMounts:
-          - name: prometheus-storage-volume
-            mountPath: /prometheus
-          - name: prometheus-config-volume
-            mountPath: /etc/prometheus
-          - name: thanos-objstore-config
-            mountPath: /etc/secret
-            readOnly: false
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
 
 ---
-apiVersion: v1
-kind: Service
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
 metadata:
-  name: prometheus-server
+  name: thanos-grpc-vs
   namespace: monitoring
 spec:
-  ports:
-    - name: grpc
-      port: 10901
-      targetPort: 10901
-    - name: http-sidecar
-      port: 10902
-      targetPort: 10902
+  hosts:
+  - thanos-grpc-eastus-dev.cse.ms

--- a/deploy/dev-ngsa-asb-eastus/monitoring/thanos/thanos-patch.yaml
+++ b/deploy/dev-ngsa-asb-eastus/monitoring/thanos/thanos-patch.yaml
@@ -9,6 +9,18 @@ spec:
       containers:
         - name: thanos-store
           image: acraks3i2qzkkxofr7c.azurecr.io/thanos/thanos:v0.23.0
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: thanos-store-grpc-vs
+  namespace: monitoring
+spec:
+  hosts:
+  - thanos-store-grpc-eastus-dev.cse.ms
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -21,6 +33,19 @@ spec:
       containers:
         - name: thanos-query
           image: acraks3i2qzkkxofr7c.azurecr.io/thanos/thanos:v0.23.0
+          args:
+            - query
+            - --log.level=debug
+            - --query.auto-downsampling
+            - --query.replica-label=prometheus_replica
+            - --store=thanos-grpc-eastus-dev.cse.ms:443
+            - --store=thanos-store-grpc-eastus-dev.cse.ms:443
+            - --store=thanos-grpc-westus2-dev.cse.ms:443
+            - --grpc-client-tls-secure
+            - --grpc-address=0.0.0.0:10901
+            - --http-address=0.0.0.0:10902
+            - --query.partial-response
+
 ---
 apiVersion: apps/v1
 kind: StatefulSet

--- a/deploy/dev-ngsa-asb-westus2/istio/kustomization.yaml
+++ b/deploy/dev-ngsa-asb-westus2/istio/kustomization.yaml
@@ -7,11 +7,12 @@ patches:
   - patch: |
         - op: replace
           path: "/spec/servers/0/hosts"
-          value: 
+          value:
             - "ngsa/ngsa-memory-westus2-dev.cse.ms"
             - "ngsa/ngsa-cosmos-westus2-dev.cse.ms"
             - "ngsa/ngsa-java-westus2-dev.cse.ms"
             - "monitoring/grafana-westus2-dev.cse.ms"
+            - "monitoring/thanos-grpc-westus2-dev.cse.ms"
             - "loderunner/loderunner-westus2-dev.cse.ms"
 
         - op: add
@@ -32,11 +33,11 @@ patches:
 
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/resources/requests/cpu"
-          value: 500m  
+          value: 500m
 
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/resources/requests/memory"
-          value: 256M  
+          value: 256M
 
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/service/loadBalancerIP"
@@ -44,7 +45,7 @@ patches:
 
         - op: add
           path: "/spec/meshConfig"
-          value: 
+          value:
             accessLogEncoding: JSON
             accessLogFile: "/dev/stdout"
             accessLogFormat: |
@@ -98,7 +99,7 @@ patches:
   - patch: |
         - op: replace
           path: "/spec/parameters/keyvaultName"
-          value: "kv-aks-3i2qzkkxofr7c"   
+          value: "kv-aks-3i2qzkkxofr7c"
     target:
       kind: SecretProviderClass
       name: istio-ingress-tls-secret-csi-akv

--- a/deploy/dev-ngsa-asb-westus2/monitoring/prometheus/prometheus-patch.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/prometheus/prometheus-patch.yaml
@@ -8,12 +8,12 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: docker.io/prom/prometheus:v2.30.0
+        image: acraks3i2qzkkxofr7c.azurecr.io/prom/prometheus:v2.30.0
         env:
           - name: PROM_EXT_LABEL_CLUSTER
             value: aks-3i2qzkkxofr7c-westus2
       - name: thanos
-        image: quay.io/thanos/thanos:v0.23.0
+        image: acraks3i2qzkkxofr7c.azurecr.io/thanos/thanos:v0.23.0
 
 ---
 

--- a/deploy/dev-ngsa-asb-westus2/monitoring/prometheus/prometheus-patch.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/prometheus/prometheus-patch.yaml
@@ -8,12 +8,12 @@ spec:
     spec:
       containers:
       - name: prometheus
-        image: acraks3i2qzkkxofr7c.azurecr.io/prom/prometheus:v2.30.0
+        image: docker.io/prom/prometheus:v2.30.0
         env:
           - name: PROM_EXT_LABEL_CLUSTER
             value: aks-3i2qzkkxofr7c-westus2
       - name: thanos
-        image: acraks3i2qzkkxofr7c.azurecr.io/thanos/thanos:v0.23.0
+        image: quay.io/thanos/thanos:v0.23.0
 
 ---
 

--- a/deploy/dev-ngsa-asb-westus2/monitoring/prometheus/prometheus-patch.yaml
+++ b/deploy/dev-ngsa-asb-westus2/monitoring/prometheus/prometheus-patch.yaml
@@ -6,87 +6,22 @@ metadata:
 spec:
   template:
     spec:
-      volumes:
-      - name: prometheus-config-shared
-        emptyDir: {}
-      - name: thanos-objstore-config
-        secret:
-          secretName: thanos-objstore-config
       containers:
       - name: prometheus
         image: acraks3i2qzkkxofr7c.azurecr.io/prom/prometheus:v2.30.0
-        args:
-        # Base args
-        - "--config.file=/etc/prometheus/prometheus.yml"
-        - "--storage.tsdb.path=/prometheus/"
-        - "--storage.tsdb.retention.size=3900MB"
-        - "--storage.tsdb.retention.time=7d"
-        - "--enable-feature=expand-external-labels" # for env substitution of external lables in cm
-        # Below args added for thanos
-        - "--storage.tsdb.min-block-duration=2h"
-        - "--storage.tsdb.max-block-duration=2h"
-        - "--web.enable-lifecycle"
-        - "--web.enable-admin-api"
         env:
           - name: PROM_EXT_LABEL_CLUSTER
             value: aks-3i2qzkkxofr7c-westus2
       - name: thanos
         image: acraks3i2qzkkxofr7c.azurecr.io/thanos/thanos:v0.23.0
-        imagePullPolicy: Always
-        args:
-          - "sidecar"
-          - "--log.level=debug"
-          - "--tsdb.path=/prometheus/"
-          - "--prometheus.url=http://localhost:9090"
-          - "--objstore.config-file=/etc/secret/thanos-storage-config.yaml"
-          - "--reloader.config-file=/etc/prometheus/prometheus.yml"
-        env:
-          - name : THANOS_OBJSTORE_CONFIG
-            value: /etc/secret/thanos-storage-config.yaml
-        ports:
-          - name: http-sidecar
-            containerPort: 10902
-          - name: grpc
-            containerPort: 10901
-        resources:
-          requests:
-            cpu: '100m'
-            memory: '64Mi'
-          limits:
-            cpu: '250m'
-            memory: '256Mi'
-        livenessProbe:
-            httpGet:
-              port: 10902
-              path: /-/healthy
-        readinessProbe:
-          httpGet:
-            port: 10902
-            path: /-/ready
-        volumeMounts:
-          - name: prometheus-storage-volume
-            mountPath: /prometheus
-          - name: prometheus-config-volume
-            mountPath: /etc/prometheus
-          - name: thanos-objstore-config
-            mountPath: /etc/secret
-            readOnly: false
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-              - ALL
+
 ---
-apiVersion: v1
-kind: Service
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
 metadata:
-  name: prometheus-server
+  name: thanos-grpc-vs
   namespace: monitoring
 spec:
-  ports:
-    - name: grpc
-      port: 10901
-      targetPort: 10901
-    - name: http-sidecar
-      port: 10902
-      targetPort: 10902
+  hosts:
+  - thanos-grpc-westus2-dev.cse.ms

--- a/deploy/pre-ngsa-asb-centralus/istio/kustomization.yaml
+++ b/deploy/pre-ngsa-asb-centralus/istio/kustomization.yaml
@@ -7,12 +7,13 @@ patches:
   - patch: |
         - op: replace
           path: "/spec/servers/0/hosts"
-          value: 
+          value:
           - "ngsa/ngsa-memory-centralus-pre.cse.ms"
           - "ngsa/ngsa-cosmos-centralus-pre.cse.ms"
           - "ngsa/ngsa-java-centralus-pre.cse.ms"
           - "monitoring/grafana-centralus-pre.cse.ms"
-          - "loderunner/loderunner-centralus-pre.cse.ms"            
+          - "monitoring/thanos-grpc-centralus-pre.cse.ms"
+          - "loderunner/loderunner-centralus-pre.cse.ms"
 
         - op: add
           path: "/spec/servers/0/tls"
@@ -32,11 +33,11 @@ patches:
 
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/resources/requests/cpu"
-          value: 50m  
+          value: 50m
 
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/resources/requests/memory"
-          value: 128M  
+          value: 128M
 
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/service/loadBalancerIP"
@@ -62,7 +63,7 @@ patches:
   - patch: |
         - op: replace
           path: "/spec/parameters/keyvaultName"
-          value: "kv-aks-fykg5bqasutle"   
+          value: "kv-aks-fykg5bqasutle"
     target:
       kind: SecretProviderClass
       name: istio-ingress-tls-secret-csi-akv

--- a/deploy/pre-ngsa-asb-centralus/monitoring/prometheus/prometheus-patch.yaml
+++ b/deploy/pre-ngsa-asb-centralus/monitoring/prometheus/prometheus-patch.yaml
@@ -12,3 +12,16 @@ spec:
         env:
           - name: PROM_EXT_LABEL_CLUSTER
             value: aks-fykg5bqasutle-centralus
+      - name: thanos
+        image: acraksfykg5bqasutle.azurecr.io/thanos/thanos:v0.23.0
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: thanos-grpc-vs
+  namespace: monitoring
+spec:
+  hosts:
+  - thanos-grpc-centralus-pre.cse.ms

--- a/deploy/pre-ngsa-asb-eastus/istio/kustomization.yaml
+++ b/deploy/pre-ngsa-asb-eastus/istio/kustomization.yaml
@@ -7,11 +7,13 @@ patches:
   - patch: |
         - op: replace
           path: "/spec/servers/0/hosts"
-          value: 
+          value:
           - "ngsa/ngsa-memory-eastus-pre.cse.ms"
           - "ngsa/ngsa-cosmos-eastus-pre.cse.ms"
           - "ngsa/ngsa-java-eastus-pre.cse.ms"
           - "monitoring/grafana-eastus-pre.cse.ms"
+          - "monitoring/thanos-grpc-eastus-pre.cse.ms"
+          - "monitoring/thanos-store-grpc-eastus-pre.cse.ms"
 
         - op: add
           path: "/spec/servers/0/tls"
@@ -31,12 +33,12 @@ patches:
 
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/resources/requests/cpu"
-          value: 50m  
+          value: 50m
 
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/resources/requests/memory"
-          value: 128M 
-            
+          value: 128M
+
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/service/loadBalancerIP"
           value: 10.240.4.4
@@ -61,7 +63,7 @@ patches:
   - patch: |
         - op: replace
           path: "/spec/parameters/keyvaultName"
-          value: "kv-aks-fykg5bqasutle"   
+          value: "kv-aks-fykg5bqasutle"
     target:
       kind: SecretProviderClass
       name: istio-ingress-tls-secret-csi-akv

--- a/deploy/pre-ngsa-asb-eastus/monitoring/grafana/grafana-patch.yaml
+++ b/deploy/pre-ngsa-asb-eastus/monitoring/grafana/grafana-patch.yaml
@@ -15,7 +15,7 @@ spec:
           - name: GF_SERVER_DOMAIN
             value: "grafana-eastus-pre.cse.ms"
           - name: PROMETHEUS_QUERY_URL # For data source
-            value: "http://prometheus-server.monitoring.svc:9090"
+            value: "http://thanos-query.monitoring.svc.cluster.local:10902"
           - name : AZURE_LA_WORKSPACE # For data source
             value: "b51964b6-4a46-46f2-80b9-01f0649e63f5"
           - name: GF_AUTH_AZUREAD_CLIENT_SECRET

--- a/deploy/pre-ngsa-asb-eastus/monitoring/kustomization.yaml
+++ b/deploy/pre-ngsa-asb-eastus/monitoring/kustomization.yaml
@@ -1,9 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+- ../../base/apps/monitoring/thanos/ # First apply thanos
 - ../../base/apps/monitoring/ # Then apply rest of monitoring
 - grafana/04-grafana-pod-identity.yaml
 patchesStrategicMerge:
+- "thanos/thanos-patch.yaml"
 - prometheus/prometheus-patch.yaml
 - grafana/dashboards/ngsa-az-blocked-traffic.yaml
 - grafana/dashboards/ngsa-az-monitor-perf.yaml

--- a/deploy/pre-ngsa-asb-eastus/monitoring/prometheus/prometheus-patch.yaml
+++ b/deploy/pre-ngsa-asb-eastus/monitoring/prometheus/prometheus-patch.yaml
@@ -12,3 +12,16 @@ spec:
         env:
           - name: PROM_EXT_LABEL_CLUSTER
             value: aks-fykg5bqasutle-eastus
+      - name: thanos
+        image: acraksfykg5bqasutle.azurecr.io/thanos/thanos:v0.23.0
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: thanos-grpc-vs
+  namespace: monitoring
+spec:
+  hosts:
+  - thanos-grpc-eastus-pre.cse.ms

--- a/deploy/pre-ngsa-asb-eastus/monitoring/thanos/thanos-patch.yaml
+++ b/deploy/pre-ngsa-asb-eastus/monitoring/thanos/thanos-patch.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+    name: thanos-store
+    namespace: monitoring
+spec:
+  template:
+    spec:
+      containers:
+        - name: thanos-store
+          image: acraksfykg5bqasutle.azurecr.io/thanos/thanos:v0.23.0
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: thanos-store-grpc-vs
+  namespace: monitoring
+spec:
+  hosts:
+  - thanos-store-grpc-eastus-pre.cse.ms
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: thanos-query
+    namespace: monitoring
+spec:
+  template:
+    spec:
+      containers:
+        - name: thanos-query
+          image: acraksfykg5bqasutle.azurecr.io/thanos/thanos:v0.23.0
+          args:
+            - query
+            - --log.level=debug
+            - --query.auto-downsampling
+            - --query.replica-label=prometheus_replica
+            - --store=thanos-grpc-eastus-pre.cse.ms:443
+            - --store=thanos-store-grpc-eastus-pre.cse.ms:443
+            - --store=thanos-grpc-westus2-pre.cse.ms:443
+            - --store=thanos-grpc-centralus-pre.cse.ms:443
+            - --grpc-client-tls-secure
+            - --grpc-address=0.0.0.0:10901
+            - --http-address=0.0.0.0:10902
+            - --query.partial-response
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+    name: thanos-compactor
+    namespace: monitoring
+spec:
+  template:
+    spec:
+      containers:
+        - name: thanos-compactor
+          image: acraksfykg5bqasutle.azurecr.io/thanos/thanos:v0.23.0

--- a/deploy/pre-ngsa-asb-westus2/istio/kustomization.yaml
+++ b/deploy/pre-ngsa-asb-westus2/istio/kustomization.yaml
@@ -7,11 +7,12 @@ patches:
   - patch: |
         - op: replace
           path: "/spec/servers/0/hosts"
-          value: 
+          value:
           - "ngsa/ngsa-memory-westus2-pre.cse.ms"
           - "ngsa/ngsa-cosmos-westus2-pre.cse.ms"
           - "ngsa/ngsa-java-westus2-pre.cse.ms"
           - "monitoring/grafana-westus2-pre.cse.ms"
+          - "monitoring/thanos-grpc-westus2-pre.cse.ms"
 
         - op: add
           path: "/spec/servers/0/tls"
@@ -31,11 +32,11 @@ patches:
 
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/resources/requests/cpu"
-          value: 50m  
+          value: 50m
 
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/resources/requests/memory"
-          value: 128M 
+          value: 128M
 
         - op: replace
           path: "/spec/components/ingressGateways/0/k8s/service/loadBalancerIP"
@@ -61,7 +62,7 @@ patches:
   - patch: |
         - op: replace
           path: "/spec/parameters/keyvaultName"
-          value: "kv-aks-fykg5bqasutle"   
+          value: "kv-aks-fykg5bqasutle"
     target:
       kind: SecretProviderClass
       name: istio-ingress-tls-secret-csi-akv

--- a/deploy/pre-ngsa-asb-westus2/monitoring/prometheus/prometheus-patch.yaml
+++ b/deploy/pre-ngsa-asb-westus2/monitoring/prometheus/prometheus-patch.yaml
@@ -12,3 +12,16 @@ spec:
         env:
           - name: PROM_EXT_LABEL_CLUSTER
             value: aks-fykg5bqasutle-westus2
+      - name: thanos
+        image: acraksfykg5bqasutle.azurecr.io/thanos/thanos:v0.23.0
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: thanos-grpc-vs
+  namespace: monitoring
+spec:
+  hosts:
+  - thanos-grpc-westus2-pre.cse.ms

--- a/flux-init/base/gotk-repo.yaml
+++ b/flux-init/base/gotk-repo.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: aakindele/deploy-thanos-realtime-2
   # secretRef: # We're accessing ngs-asb as readonly repo
   #   name: flux-system
   url: https://github.com/retaildevcrews/ngsa-asb

--- a/flux-init/base/gotk-repo.yaml
+++ b/flux-init/base/gotk-repo.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: aakindele/deploy-thanos-realtime-2
+    branch: main
   # secretRef: # We're accessing ngs-asb as readonly repo
   #   name: flux-system
   url: https://github.com/retaildevcrews/ngsa-asb

--- a/flux-init/init-dev/kustomization.yaml
+++ b/flux-init/init-dev/kustomization.yaml
@@ -6,7 +6,7 @@ patches:
   - patch: |
       - op: replace
         path: "/spec/template/spec/containers/0/image"
-        value: "acraks3i2qzkkxofr7c.azurecr.io/fluxcd/helm-controller:v0.22.2"        
+        value: "docker.io/fluxcd/helm-controller:v0.22.2"
     target:
       kind: Deployment
       name: helm-controller
@@ -14,7 +14,7 @@ patches:
   - patch: |
       - op: replace
         path: "/spec/template/spec/containers/0/image"
-        value: "acraks3i2qzkkxofr7c.azurecr.io/fluxcd/kustomize-controller:v0.27.0"        
+        value: "docker.io/fluxcd/kustomize-controller:v0.27.0"
     target:
       kind: Deployment
       name: kustomize-controller
@@ -22,7 +22,7 @@ patches:
   - patch: |
       - op: replace
         path: "/spec/template/spec/containers/0/image"
-        value: "acraks3i2qzkkxofr7c.azurecr.io/fluxcd/notification-controller:v0.25.1"        
+        value: "docker.io/fluxcd/notification-controller:v0.25.1"
     target:
       kind: Deployment
       name: notification-controller
@@ -30,7 +30,7 @@ patches:
   - patch: |
       - op: replace
         path: "/spec/template/spec/containers/0/image"
-        value: "acraks3i2qzkkxofr7c.azurecr.io/fluxcd/source-controller:v0.26.1"        
+        value: "docker.io/fluxcd/source-controller:v0.26.1"
     target:
       kind: Deployment
       name: source-controller
@@ -45,4 +45,3 @@ patches:
       kind: Kustomization
       name: flux-system
       namespace: flux-system
-

--- a/flux-init/init-dev/kustomization.yaml
+++ b/flux-init/init-dev/kustomization.yaml
@@ -6,7 +6,7 @@ patches:
   - patch: |
       - op: replace
         path: "/spec/template/spec/containers/0/image"
-        value: "docker.io/fluxcd/helm-controller:v0.22.2"
+        value: "acraks3i2qzkkxofr7c.azurecr.io/fluxcd/helm-controller:v0.22.2"
     target:
       kind: Deployment
       name: helm-controller
@@ -14,7 +14,7 @@ patches:
   - patch: |
       - op: replace
         path: "/spec/template/spec/containers/0/image"
-        value: "docker.io/fluxcd/kustomize-controller:v0.27.0"
+        value: "acraks3i2qzkkxofr7c.azurecr.io/fluxcd/kustomize-controller:v0.27.0"
     target:
       kind: Deployment
       name: kustomize-controller
@@ -22,7 +22,7 @@ patches:
   - patch: |
       - op: replace
         path: "/spec/template/spec/containers/0/image"
-        value: "docker.io/fluxcd/notification-controller:v0.25.1"
+        value: "acraks3i2qzkkxofr7c.azurecr.io/fluxcd/notification-controller:v0.25.1"
     target:
       kind: Deployment
       name: notification-controller
@@ -30,7 +30,7 @@ patches:
   - patch: |
       - op: replace
         path: "/spec/template/spec/containers/0/image"
-        value: "docker.io/fluxcd/source-controller:v0.26.1"
+        value: "acraks3i2qzkkxofr7c.azurecr.io/fluxcd/source-controller:v0.26.1"
     target:
       kind: Deployment
       name: source-controller

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -84,6 +84,30 @@ kubectl create secret generic thanos-objstore-config \
 
 ```
 
+#### Setup private DNS
+
+Create DNS records in the private DNS zone to allow cross cluster communication
+
+```bash
+
+export ASB_AKS_PRIVATE_IP="$ASB_SPOKE_IP_PREFIX".4.4
+
+az network private-dns record-set a add-record \
+  -g $ASB_RG_CORE \
+  -z $ASB_DNS_ZONE \
+  -n "thanos-grpc-${ASB_SPOKE_LOCATION}-${ASB_ENV}" \
+  -a $ASB_AKS_PRIVATE_IP \
+  --query fqdn
+
+az network private-dns record-set a add-record \
+  -g $ASB_RG_CORE \
+  -z $ASB_DNS_ZONE \
+  -n "thanos-store-grpc-${ASB_SPOKE_LOCATION}-${ASB_ENV}" \
+  -a $ASB_AKS_PRIVATE_IP \
+  --query fqdn
+
+```
+
 ### Create Deployment Templates
 
 ```bash
@@ -103,6 +127,8 @@ cat templates/monitoring/02-prometheus.yaml | envsubst  > $ASB_GIT_PATH/monitori
 > Skip this section for all other clusters.
 
 ```bash
+
+mkdir -p  $ASB_GIT_PATH/monitoring/thanos
 
 # create thanos querier deployment file
 cat templates/monitoring/thanos/thanos-querier.yaml | envsubst  > $ASB_GIT_PATH/monitoring/thanos/thanos-querier.yaml

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -128,8 +128,6 @@ cat templates/monitoring/02-prometheus.yaml | envsubst  > $ASB_GIT_PATH/monitori
 
 ```bash
 
-mkdir -p  $ASB_GIT_PATH/monitoring/thanos
-
 # create thanos querier deployment file
 cat templates/monitoring/thanos/thanos-querier.yaml | envsubst  > $ASB_GIT_PATH/monitoring/thanos/thanos-querier.yaml
 


### PR DESCRIPTION
# Type of PR

- [x] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR

- Add Thanos to preprod including real-time metrics
- Update the existing dev deployment to include real-time metrics
- Move Thanos sidecar configuration from environment specific configs to base config
- Increased pod memory limit on Azure policy to allow for more memory on some of the Thanos components
  - TODO: [New task](https://github.com/retaildevcrews/wcnp/issues/1045) to investigate resource usage and recommendations for Thanos
- Added instructions for creating private DNS records for Thanos components to communicate cross-cluster
  - This allows the Thanos Observer cluster to fetch real-time metrics from the Observee clusters

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Validation

- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/488
