### PR TITLE
Added burst namespace for kustomization

### DIFF
--- a/deploy/dev-ngsa-asb-westus2/burst/kustomization.yaml
+++ b/deploy/dev-ngsa-asb-westus2/burst/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- namespace.yaml
+- burst-metrics-service.yaml
+- remote-filter-ngsa-cosmos.yaml

--- a/deploy/dev-ngsa-asb-westus2/burst/namespace.yaml
+++ b/deploy/dev-ngsa-asb-westus2/burst/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: burstservice
+  name: burstservice


### PR DESCRIPTION
# Type of PR

- [X] Code changes

## Purpose of PR
Kustomization was failing since `burstservice` namespace was not created by flux and is not available by default.

For that reason, we've added namespace file and kustomization file for burst metrics in WestUS2 dev only (since burst metrics is only deployed in westus2).

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/1047