### PR TITLE
Burst Headers Issue Fix

### DIFF
--- a/deploy/dev-ngsa-asb-westus2/burst/burst-flux-kustomization.yaml
+++ b/deploy/dev-ngsa-asb-westus2/burst/burst-flux-kustomization.yaml
@@ -10,7 +10,7 @@ spec:
     namespace: istio-system
   interval: 1m0s # detect drift and undo kubectl edits every minute
   prune: true # remove stale resources from cluster
-  targetNamespace: burstservice # overwrite the ns for resources in path
+  # targetNamespace: burstservice # overwrite the ns for resources in path
   path: ./deploy/dev-ngsa-asb-westus2/burst
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

<!-- Use the check list below to ensure your branch is ready for PR. -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR
<!-- Concise description of the problem and the solution or the feature being added -->
To fix a burst issue that was preventing x-load-feedback header from being injected

## Does this introduce a breaking change

- [ ] YES
- [x] NO

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
## Validation

- [ ] Unit tests updated and ran successfully
- [ ] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/1076
