### PR TITLE
Update Thanos resource requests based on average and burst usage

### DIFF
--- a/deploy/base/apps/monitoring/prometheus/02-prometheus.yaml
+++ b/deploy/base/apps/monitoring/prometheus/02-prometheus.yaml
@@ -167,10 +167,10 @@ spec:
               containerPort: 10901
           resources:
             requests:
-              cpu: '100m'
+              cpu: '50m'
               memory: '64Mi'
             limits:
-              cpu: '250m'
+              cpu: '200m'
               memory: '256Mi'
           livenessProbe:
               httpGet:

--- a/deploy/base/apps/monitoring/thanos/thanos-compactor.yaml
+++ b/deploy/base/apps/monitoring/thanos/thanos-compactor.yaml
@@ -32,8 +32,8 @@ spec:
               containerPort: 10902
           resources:
             requests:
-              cpu: '500m'
-              memory: '512Mi'
+              cpu: '200m'
+              memory: '256Mi'
             limits:
               cpu: '1000m'
               memory: '1024Mi'

--- a/deploy/base/apps/monitoring/thanos/thanos-querier.yaml
+++ b/deploy/base/apps/monitoring/thanos/thanos-querier.yaml
@@ -33,10 +33,10 @@ spec:
             - --query.partial-response
           resources:
             requests:
-              cpu: '100m'
+              cpu: '50m'
               memory: '64Mi'
             limits:
-              cpu: '250m'
+              cpu: '200m'
               memory: '256Mi'
           livenessProbe:
               httpGet:

--- a/deploy/base/apps/monitoring/thanos/thanos-store.yaml
+++ b/deploy/base/apps/monitoring/thanos/thanos-store.yaml
@@ -41,11 +41,11 @@ spec:
               containerPort: 10900
           resources:
             requests:
-              cpu: '500m'
-              memory: '512Mi'
+              cpu: '100m'
+              memory: '192Mi'
             limits:
-              cpu: '1000m'
-              memory: '1024Mi'
+              cpu: '400m'
+              memory: '768Mi'
           livenessProbe:
               httpGet:
                 port: 10902


### PR DESCRIPTION
# Type of PR

- [ ] Documentation changes
- [x] Code changes
- [ ] Test changes
- [ ] CI-CD changes
- [ ] GitHub Template changes

## PR Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code follows the code style of this project.
- [ ] I ran lint checks locally prior to submission.
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

## Purpose of PR

Update resource requests and limits for Thanos components based on actual usage. The requests and limits are based on average usage. For thanos-compactor, the limit is increased a bit more than others to account for intermittent burst usage in CPU.

## Does this introduce a breaking change

- [ ] YES
- [x] NO

## Validation

- [ ] Unit tests updated and ran successfully
- [x] Update documentation or issue referenced above

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/1045