### PR TITLE
Bugfix/thanos urlfix

### DIFF
--- a/deploy/dev-ngsa-asb-eastus/monitoring/thanos/thanos-patch.yaml
+++ b/deploy/dev-ngsa-asb-eastus/monitoring/thanos/thanos-patch.yaml
@@ -40,7 +40,7 @@ spec:
             - --query.replica-label=prometheus_replica
             - --store=thanos-grpc-eastus-dev.austinrdc.dev:443
             - --store=thanos-store-grpc-eastus-dev.austinrdc.dev:443
-            - --store=thanos-grpc-westus2-dev.austinrdc.dev:443
+            - --store=thanos-grpc-westus3-dev.austinrdc.dev:443
             - --grpc-client-tls-secure
             - --grpc-address=0.0.0.0:10901
             - --http-address=0.0.0.0:10902

--- a/deploy/pre-ngsa-asb-eastus/monitoring/thanos/thanos-patch.yaml
+++ b/deploy/pre-ngsa-asb-eastus/monitoring/thanos/thanos-patch.yaml
@@ -40,7 +40,7 @@ spec:
             - --query.replica-label=prometheus_replica
             - --store=thanos-grpc-eastus-pre.austinrdc.dev:443
             - --store=thanos-store-grpc-eastus-pre.austinrdc.dev:443
-            - --store=thanos-grpc-westus2-pre.austinrdc.dev:443
+            - --store=thanos-grpc-westus3-pre.austinrdc.dev:443
             - --store=thanos-grpc-centralus-pre.austinrdc.dev:443
             - --grpc-client-tls-secure
             - --grpc-address=0.0.0.0:10901


### PR DESCRIPTION
# Type of PR

> **Note** that this PR will be merged into `wcnp-dev` not `main` if approved.

- [X] Code changes

## Purpose of PR
Our Grafana dashboards were empty and wasn't getting any data from Prometheus although from Proemtheus UI the queries were running fine.

There was a slight discrepancy in Thanos's configuration.
As well, as private DNS record wasn't created according to documentation.
So just 

## Does this introduce a breaking change

- [ ] YES
- [X] NO

## Validation

- [X] Tested after deploying to EastUS

## Issues Closed or Referenced

- Closes https://github.com/retaildevcrews/wcnp/issues/1107